### PR TITLE
Updated the Info.plist for Xcode [REDACTED] support.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>63FC1C47-140D-42B0-BB4D-A10B2D225574</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCode4_beginning_of_line</string>
 	<key>XC4Compatible</key>


### PR DESCRIPTION
Your work on this project, @insanehunter, has kept me from pulling out my hair over the past two years, so imagine my sadness (and partial hair loss) when I discovered it wouldn't work at all in the latest Xcode [REDACTED] preview v3 that was released this past Monday!

Evidently all that's usually needed is a modification to the `Info.plist` file to add support for specific Xcode version UUIDs — I've done so in this pull request.

If you'd like to merge this into master (or if you'd like to open a separate branch for Xcode 5 support; this should be backwards compatible, though), that would be amazing. And like I mentioned earlier: thank you for your work on this project. It solves a _major_ inconvenience for me!
