### PR TITLE
improve -deleteToBeginningOfLine: functionality

### DIFF
--- a/Xcode_beginning_of_line.m
+++ b/Xcode_beginning_of_line.m
@@ -46,13 +46,27 @@ static void doCommandBySelector( id self_, SEL _cmd, SEL selector )
             
             NSRange range = NSMakeRange(start, end - start);
             
-            [self setSelectedRange:range];
-            [self scrollRangeToVisible:range];
-            
-            // We are now at the beginning of line,
-            // call -deleteToEndOfLine to keep the same selection position.
             if (selector == @selector(deleteToBeginningOfLine:)) {
-                [self deleteToEndOfLine:self];
+                // handle deleteToBeginningOfLine: method
+                NSRange deleteRange;
+                if (caretLocation == codeStartRange.location) {
+                    // we are already at the beginnig of code, delete all the way to start of line
+                    deleteRange = NSMakeRange(lineRange.location, codeStartRange.location);
+                }
+                else {
+                    // delete from caret to code start
+                    deleteRange = NSMakeRange(lineRange.location+codeStartRange.location, caretLocation-codeStartRange.location);
+                }
+                
+                [self setSelectedRange:deleteRange];
+                // We cannot undo if we use -replaceCharactersInRange:withString:,
+                // we need to use -insertText: to delete the text instead.
+                [self insertText:@""];
+            }
+            else {
+                // handle other methods
+                [self setSelectedRange:range];
+                [self scrollRangeToVisible:range];
             }
             
             return;


### PR DESCRIPTION
Hey, it's me again. I found that from my last fix, it shouldn't delete the whole line if I cmd+del from the middle of that line. So I rebase and added some changes. Please have a look.

changes:
- cmd+del doesn't delete the whole line anymore
- cmd+del will delete all whitespace in front of it if caret is already at the beginning of the line
