### PR TITLE
Added Ctrl+a support

### DIFF
--- a/Xcode_beginning_of_line.m
+++ b/Xcode_beginning_of_line.m
@@ -15,6 +15,7 @@ static void doCommandBySelector( id self_, SEL _cmd, SEL selector )
         
         if (selector == @selector(deleteToBeginningOfLine:) ||
             selector == @selector(moveToBeginningOfLine:) ||
+            selector == @selector(moveToBeginningOfParagraph:) ||
             selector == @selector(moveToLeftEndOfLine:) || selectionModified)
         {
             NSTextView *self = (NSTextView *)self_;


### PR DESCRIPTION
An other common way to go to the beginning of line in Mac OS X is the command Ctrl+a, I have added the selector for this command to work with the plugin.
