### PR TITLE
Add Ctrl-Shift-a support.

### DIFF
--- a/Xcode_beginning_of_line.m
+++ b/Xcode_beginning_of_line.m
@@ -79,7 +79,8 @@ static void doCommandBySelector( id self_, SEL _cmd, SEL selector )
 {
     do {
         bool selectionModified = selector == @selector(moveToBeginningOfLineAndModifySelection:) ||
-        selector == @selector(moveToLeftEndOfLineAndModifySelection:);
+        selector == @selector(moveToLeftEndOfLineAndModifySelection:) ||
+        selector == @selector(moveToBeginningOfParagraphAndModifySelection:);
         
         if (selector == @selector(deleteToBeginningOfLine:) ||
             selector == @selector(moveToBeginningOfLine:) ||


### PR DESCRIPTION
Since Ctrl-a has been supported, I think it's appropriate to support Ctrl-Shift-a to extend the selection to the beginning.
