### PR TITLE
Fix delete-to-beginning issue.

### DIFF
--- a/Xcode_beginning_of_line.m
+++ b/Xcode_beginning_of_line.m
@@ -397,9 +397,9 @@ static void doCommandBySelector( id self_, SEL _cmd, SEL selector )
             if (selector == @selector(deleteToBeginningOfLine:)) {
                 // handle deleteToBeginningOfLine: method
                 NSRange deleteRange;
-                if (caretLocation == codeStartRange.location) {
+                if (caretLocation <= codeStartRange.location) {
                     // we are already at the beginnig of code, delete all the way to start of line
-                    deleteRange = NSMakeRange(lineRange.location, codeStartRange.location);
+                    deleteRange = NSMakeRange(lineRange.location, caretLocation);
                 }
                 else {
                     // delete from caret to code start


### PR DESCRIPTION
When the cursor is ahead of the first character of the current line, and hit command+delete, Xcode crashes.

The reason is that the "caretLocation" is smaller than the "codeStartRange.location", and the calculated "deleteRange"'s length is minus.