### PR TITLE
Don't NSLog() anymore

### DIFF
--- a/Xcode_beginning_of_line.m
+++ b/Xcode_beginning_of_line.m
@@ -445,6 +445,6 @@ static void doCommandBySelector( id self_, SEL _cmd, SEL selector )
     return;
     
 failed:
-    NSLog(@"%@ failed to launch :(", NSStringFromClass([self class]));
+    return;
 }
 @end


### PR DESCRIPTION
Would be nice if we could get rid of this, it pollutes the output of `xcodebuild` on the command line.