### PR TITLE
Xcode 6.4 beta compatibility.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -34,6 +34,7 @@
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
+		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>Xcode_beginning_of_line</string>

--- a/Info.plist
+++ b/Info.plist
@@ -35,6 +35,7 @@
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>Xcode_beginning_of_line</string>


### PR DESCRIPTION
This includes the new `DVTPlugInCompatibilityUUID` value from the following command: 

```
$ defaults read /Applications/Xcode-beta.app/Contents/Info DVTPlugInCompatibilityUUID
```

The first value is from beta 1, the second from beta 2.