### PR TITLE
Add Xcode 6.4b4 UUID.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -38,6 +38,7 @@
 		<string>8DC44374-2B35-4C57-A6FE-2AD66A36AAD9</string>
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
+		<string>5EDAC44F-8E0B-42C9-9BEF-E9C12EEC4949</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>Xcode_beginning_of_line</string>


### PR DESCRIPTION
The UUID ending in `949` is the UUID for Xcode 6.4 Beta 4.

(Come to think of it, if we get Xcode 6.4 GM today along with iOS 8.4 GM, I'll update this branch if the UUID changes yet again.)