### PR TITLE
Add UUID for Xcode 6.4 compatibility.

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -39,6 +39,7 @@
 		<string>E969541F-E6F9-4D25-8158-72DC3545A6C6</string>
 		<string>AABB7188-E14E-4433-AD3B-5CD791EAD9A3</string>
 		<string>5EDAC44F-8E0B-42C9-9BEF-E9C12EEC4949</string>
+		<string>7FDF5C7A-131F-4ABB-9EDC-8C5F8F0B8A90</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>Xcode_beginning_of_line</string>


### PR DESCRIPTION
The UUID ending in `A90` is the UUID for Xcode 6.4 GM.